### PR TITLE
Update builtin straight.

### DIFF
--- a/straight/default.nix
+++ b/straight/default.nix
@@ -6,7 +6,7 @@ trivialBuild rec {
   src = fetchFromGitHub {
     owner = "raxod502";
     repo = "straight.el";
-    rev = "e1390a933b6f5a15079d6dec91eac97a17aad10c";
-    sha256 = "sha256-fzIvJ5sDNDtF0w8t1WtM2SpnWT8zM2RG/EiSthy1URU=";
+    rev = "5541697ceee7e7ba937eddebba44f1e8e8af6a4f";
+    sha256 = "sha256-Ecf0QU/ZbCirGHYBSZGIA4Gb0ION56S/pOElYZXgytI=";
   };
 }


### PR DESCRIPTION
Hello.

This commit updates builtin straight to the latest version, which has support for native-comp-* variables.

With this update the nix-doom-emacs will be able to work with latest emacsGcc.