### PR TITLE
Revert "Update builtin straight."

### DIFF
--- a/straight/default.nix
+++ b/straight/default.nix
@@ -6,7 +6,7 @@ trivialBuild rec {
   src = fetchFromGitHub {
     owner = "raxod502";
     repo = "straight.el";
-    rev = "5541697ceee7e7ba937eddebba44f1e8e8af6a4f";
-    sha256 = "sha256-Ecf0QU/ZbCirGHYBSZGIA4Gb0ION56S/pOElYZXgytI=";
+    rev = "e1390a933b6f5a15079d6dec91eac97a17aad10c";
+    sha256 = "sha256-fzIvJ5sDNDtF0w8t1WtM2SpnWT8zM2RG/EiSthy1URU=";
   };
 }


### PR DESCRIPTION
Reverts vlaci/nix-straight.el#3

In nix-doom-emacs:
```
❯ nix flake check
warning: Git tree '/home/vlaci/devel/git/github.com/vlaci/nix-doom-emacs' is dirty
error: builder for '/nix/store/j28kig75rpr7fl6wvarklzrqm89nfqy6-emacs-straight-packages.json.drv' failed with exit code 255;
       last 4 log lines:
       > installing
       > [nix-doom-emacs] Advising doom installer to gather packages to install...
       > Loading /nix/store/scmcz8w8rj2jin5v08ysgnazqh7kldzw-doom-src/bin/doom...
       > Git executable not found. straight.el requires git
       For full logs, run 'nix log /nix/store/j28kig75rpr7fl6wvarklzrqm89nfqy6-emacs-straight-packages.json.drv'.
(use '--show-trace' to show detailed location information)
```